### PR TITLE
add labels to the metrics service and name the port used for metrics

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/jodevsa/wireguard-operator/operator
-  newTag: sha-ef1a92d9154674bdec0b15917cad2243c7b831bb
+  newTag: sha-64c91a661f4ae6dce41e311386cfe5b8309e816c

--- a/controllers/wireguard_controller.go
+++ b/controllers/wireguard_controller.go
@@ -565,7 +565,6 @@ func (r *WireguardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *WireguardReconciler) serviceForWireguard(m *vpnv1alpha1.Wireguard, serviceType corev1.ServiceType) *corev1.Service {
 	labels := labelsForWireguard(m.Name)
-	//timeoutSeconds := int32(120)
 
 	dep := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -599,10 +598,12 @@ func (r *WireguardReconciler) serviceForWireguardMetrics(m *vpnv1alpha1.Wireguar
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name + "-metrics-svc",
 			Namespace: m.Namespace,
+			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: labels,
 			Ports: []corev1.ServicePort{{
+				Name:       "metrics",
 				Protocol:   corev1.ProtocolTCP,
 				Port:       metricsPort,
 				TargetPort: intstr.FromInt(metricsPort),

--- a/release-config.yaml
+++ b/release-config.yaml
@@ -1,2 +1,2 @@
-WIREGUARD_IMAGE: "ghcr.io/jodevsa/wireguard-operator/wireguard:sha-ef1a92d9154674bdec0b15917cad2243c7b831bb"
-OPERATOR_IMAGE: "ghcr.io/jodevsa/wireguard-operator/operator:sha-ef1a92d9154674bdec0b15917cad2243c7b831bb"
+WIREGUARD_IMAGE: "ghcr.io/jodevsa/wireguard-operator/wireguard:sha-64c91a661f4ae6dce41e311386cfe5b8309e816c"
+OPERATOR_IMAGE: "ghcr.io/jodevsa/wireguard-operator/operator:sha-64c91a661f4ae6dce41e311386cfe5b8309e816c"

--- a/release.yaml
+++ b/release.yaml
@@ -486,7 +486,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/jodevsa/wireguard-operator/operator:sha-ef1a92d9154674bdec0b15917cad2243c7b831bb
+        image: ghcr.io/jodevsa/wireguard-operator/operator:sha-64c91a661f4ae6dce41e311386cfe5b8309e816c
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Add labels and name to the metrics port so that we can easily use it with Grafana service monitors in k8s