### PR TITLE
Add support for pod Wireguard sidecar

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,18 +50,22 @@ func init() {
 }
 
 func main() {
-	var agentImagePullPolicy string
+	var wgImage string
+	var wgAgentImagePullPolicy string
+	var wgSidecarImage string
+	var wgSidecarAgentImagePullPolicy string
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	var wgImage string
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&wgImage, "agent-image", "", "The image used for wireguard server")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&agentImagePullPolicy, "agent-image-pull-policy", "IfNotPresent", "Use userspace implementation")
+	flag.StringVar(&wgSidecarImage, "sidecar-image", "ghcr.io/jodevsa/wireguard-operator/sidecar:latest", "The image used for wireguard sidecar")
+	flag.StringVar(&wgSidecarImagePullPolicy, "sidecar-image-pull-policy", "IfNotPresent", "imagePullPolicy for wireguard sidecar")
+	"Enable leader election for controller manager. "+
+	"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&wgImage, "agent-image", "ghcr.io/jodevsa/wireguard-operator/agent:latest", "The image used for wireguard server")
+	flag.StringVar(&wgAgentImagePullPolicy, "agent-image-pull-policy", "IfNotPresent", "Use userspace implementation")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -92,7 +96,7 @@ func main() {
 		Client:               mgr.GetClient(),
 		Scheme:               mgr.GetScheme(),
 		AgentImage:           wgImage,
-		AgentImagePullPolicy: v1.PullPolicy(agentImagePullPolicy),
+		AgentImagePullPolicy: v1.PullPolicy(wgAgentImagePullPolicy),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Wireguard")
 		os.Exit(1)
@@ -102,6 +106,15 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WireguardPeer")
+		os.Exit(1)
+	}
+	if err = (&controllers.WireguardSidecarReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		SidecarImage:           wgSidecarImage,
+		SidecarImagePullPolicy: v1.PullPolicy(wgSidecarImagePullPolicy),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "WireguardSidecar")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mdlayher/netlink v1.7.1 // indirect
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.24.1
+	github.com/pkg/errors v0.9.1
 	github.com/vishvananda/netlink v1.1.0
 	go.opentelemetry.io/contrib v0.20.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp v0.20.0 // indirect

--- a/images/sidecar/start-wireguard.sh
+++ b/images/sidecar/start-wireguard.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+# Generate WireGuard keys
+umask 077
+
+# Start WireGuard
+wg-quick up wg0
+
+# Configure iptables to route traffic over the VPN
+iptables -A FORWARD -i eth0 -o wg0 -j ACCEPT
+iptables -A FORWARD -i wg0 -o eth0 -j ACCEPT
+iptables -t nat -A POSTROUTING -o wg0 -j MASQUERADE
+
+# Start the main container process
+exec "$@"

--- a/pkg/controllers/wireguardsidecar_controller.go
+++ b/pkg/controllers/wireguardsidecar_controller.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"time"
+
+	"github.com/jodevsa/wireguard-operator/pkg/api/v1alpha1"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	configMapName      = "wireguard-peer-config"
+	configMapNamespace = "default"
+	configMapKey       = "config"
+)
+
+type WireguardSidecarReconciler struct {
+	client.Client
+	Scheme             *runtime.Scheme
+	SidecarImage       string
+	SidecarImagePullPolicy    corev1.PullPolicy
+	RequeueAfter       time.Duration
+}
+
+func (r *WireguardSidecarReconciler) SetupWithManager(mgr ctrl.Manager) error {
+    return ctrl.NewControllerManagedBy(mgr).
+        For(&corev1.Pod{}).
+        WithEventFilter(predicate.Funcs{
+            CreateFunc: func(e event.CreateEvent) bool {
+                return r.hasSidecarAnnotation(e.Object)
+            },
+            UpdateFunc: func(e event.UpdateEvent) bool {
+                return r.hasSidecarAnnotation(e.ObjectNew)
+            },
+            DeleteFunc: func(e event.DeleteEvent) bool {
+                // Ignore delete events
+                return false
+            },
+            GenericFunc: func(e event.GenericEvent) bool {
+                // Ignore generic events
+                return false
+            },
+        }).
+        Complete(r)
+}
+
+func (r *WireguardSidecarReconciler) hasAnnotationSidecar(obj runtime.Object) bool {
+    pod, ok := obj.(*corev1.Pod)
+    if !ok {
+        return false
+    }
+
+    enable, ok := pod.Annotations["vpn.example.com/sidecar-enable"]
+    if !ok || enable != "true" {
+        return false
+    }
+
+    wgRef, ok := pod.Annotations["vpn.example.com/sidecar-wireguard-ref"]
+    if !ok || wgRef == "" {
+        r.Log.Error(fmt.Errorf("missing or empty vpn.example.com/sidecar-wireguard-ref annotation for pod %s/%s", pod.Namespace, pod.Name), "failed to reconcile pod")
+        return false
+    }
+
+    // Validate the wireguard reference here
+    // ...
+
+    // Create the wireguard peer object
+    peer := &v1alpha1.WireguardPeer{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      fmt.Sprintf("%s-sidecar", pod.Name),
+            Namespace: pod.Namespace,
+        },
+        Spec: v1alpha1.WireguardPeerSpec{
+            WireguardRef: wgRef,
+        },
+    }
+
+    // Create or update the wireguard peer object in the cluster
+    err := r.Client.CreateOrUpdate(context.Background(), peer, func() error {
+        return ctrl.SetControllerReference(pod, peer, r.Scheme)
+    })
+    if err != nil {
+        r.Log.Error(err, "failed to create or update WireguardPeer", "peer", peer)
+        return false
+    }
+
+    // Create the configmap for the peer status config
+    configMapName := fmt.Sprintf("%s-sidecar", pod.Name)
+    configMap := &corev1.ConfigMap{
+        ObjectMeta: metav1.ObjectMeta{
+            Name:      configMapName,
+            Namespace: pod.Namespace,
+        },
+        Data: map[string]string{
+            "wg0.conf": peer.Status.Config,
+        },
+    }
+
+    err = r.Client.Create(context.Background(), configMap)
+    if err != nil {
+        r.Log.Error(err, "failed to create ConfigMap", "configMap", configMap)
+        return false
+    }
+
+    // Add the configmap volume to the pod spec
+    pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+        Name: configMapName,
+        VolumeSource: corev1.VolumeSource{
+            ConfigMap: &corev1.ConfigMapVolumeSource{
+                Name: configMapName,
+            },
+        },
+    })
+
+    // Mount the configmap in the sidecar container
+    pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+        Name:  "wireguard-sidecar",
+        Image: r.SidecarImage,
+		ImagePullPolicy: r.SidecarImagePullPolicy,
+        // Add any required configuration for the sidecar container here
+        VolumeMounts: []corev1.VolumeMount{
+            {
+                Name:      configMapName,
+                MountPath: "/etc/wireguard/wg0.conf",
+                SubPath:   "wg0.conf",
+            },
+        },
+    })
+
+    return true
+}


### PR DESCRIPTION
This PR adds a sidecar which can be added to a pod by the controller when the annotation:

vpn.example.com/sidecar-enable: true is set and
vpn.example.com/sidecar-wireguard-ref: is a valid wireguard reference

The wireguard sidecar is automatically configured for the vpn and a peer is created automatically.