### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you are facing any problems please open an issue or join our [slack channel](
 - [x] Google Kubernetes Engine
   * requires `spec.mtu: "1380"`
   * Not compatible with "Container-Optimized OS with containerd" node images
+  * Not compatible with autopilot
 - [x] DigitalOcean Kubernetes
   * requires `spec.serviceType: "NodePort"`. DigitalOcean LoadBalancer does not support UDP. 
 - [ ] Amazon EKS


### PR DESCRIPTION
google kubernetes autopilot is very strict in terms of networking capabilities. I tried wireguard-operator on it and it didn't work