### PR TITLE
Allow specifying the NodePort port

### DIFF
--- a/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
+++ b/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
@@ -64,6 +64,10 @@ spec:
                   that should be used for the Wireguard VPN. This could be NodePort
                   or LoadBalancer, depending on the needs of the deployment.
                 type: string
+              nodePort:
+                description: A field that specifies the nodePort to use for the Kubernetes
+                  service when a nodePort serviceType has been selected.
+                type: string
             type: object
           status:
             description: WireguardStatus defines the observed state of Wireguard

--- a/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
+++ b/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
@@ -54,6 +54,10 @@ spec:
                 description: A string field that specifies the maximum transmission
                   unit (MTU) size for Wireguard packets for all peers.
                 type: string
+              port:
+                description: A field that specifies the value to use for a nodePort
+                  ServiceType
+                type: integer
               serviceAnnotations:
                 additionalProperties:
                   type: string
@@ -63,10 +67,6 @@ spec:
                 description: A field that specifies the type of Kubernetes service
                   that should be used for the Wireguard VPN. This could be NodePort
                   or LoadBalancer, depending on the needs of the deployment.
-                type: string
-              nodePort:
-                description: A field that specifies the nodePort to use for the Kubernetes
-                  service when a nodePort serviceType has been selected.
                 type: string
             type: object
           status:

--- a/pkg/api/v1alpha1/wireguard_types.go
+++ b/pkg/api/v1alpha1/wireguard_types.go
@@ -45,6 +45,8 @@ type WireguardSpec struct {
 	Dns string `json:"dns,omitempty"`
 	// A field that specifies the type of Kubernetes service that should be used for the Wireguard VPN. This could be NodePort or LoadBalancer, depending on the needs of the deployment.
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
+	// A field that specifies the value to use for a nodePort ServiceType
+	NodePort string `json:"port,omitempty"`
 	// A map of key value strings for service annotations
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 	// A boolean field that specifies whether IP forwarding should be enabled on the Wireguard VPN pod at startup. This can be useful to enable if the peers are having problems with sending traffic to the internet.

--- a/pkg/api/v1alpha1/wireguard_types.go
+++ b/pkg/api/v1alpha1/wireguard_types.go
@@ -46,7 +46,7 @@ type WireguardSpec struct {
 	// A field that specifies the type of Kubernetes service that should be used for the Wireguard VPN. This could be NodePort or LoadBalancer, depending on the needs of the deployment.
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 	// A field that specifies the value to use for a nodePort ServiceType
-	NodePort string `json:"port,omitempty"`
+	NodePort int `json:"port,omitempty"`
 	// A map of key value strings for service annotations
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 	// A boolean field that specifies whether IP forwarding should be enabled on the Wireguard VPN pod at startup. This can be useful to enable if the peers are having problems with sending traffic to the internet.

--- a/pkg/api/v1alpha1/wireguard_types.go
+++ b/pkg/api/v1alpha1/wireguard_types.go
@@ -46,7 +46,7 @@ type WireguardSpec struct {
 	// A field that specifies the type of Kubernetes service that should be used for the Wireguard VPN. This could be NodePort or LoadBalancer, depending on the needs of the deployment.
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 	// A field that specifies the value to use for a nodePort ServiceType
-	NodePort int `json:"port,omitempty"`
+	NodePort int32 `json:"port,omitempty"`
 	// A map of key value strings for service annotations
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 	// A boolean field that specifies whether IP forwarding should be enabled on the Wireguard VPN pod at startup. This can be useful to enable if the peers are having problems with sending traffic to the internet.

--- a/pkg/controllers/wireguard_controller.go
+++ b/pkg/controllers/wireguard_controller.go
@@ -641,6 +641,7 @@ func (r *WireguardReconciler) serviceForWireguard(m *v1alpha1.Wireguard, service
 			Selector: labels,
 			Ports: []corev1.ServicePort{{
 				Protocol:   corev1.ProtocolUDP,
+				NodePort:   m.Spec.NodePort,
 				Port:       port,
 				TargetPort: intstr.FromInt(port),
 			}},


### PR DESCRIPTION
Currently, the NodePort selected is at random. This allows ops to specify the NodePort to use for externally-managed load balancers.