### PR TITLE
Add option to enable or disable usage of WG userspace implementation

### DIFF
--- a/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
+++ b/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
@@ -68,6 +68,10 @@ spec:
                   that should be used for the Wireguard VPN. This could be NodePort
                   or LoadBalancer, depending on the needs of the deployment.
                 type: string
+              useWgUserspaceImplementation:
+                description: A boolean field that specifies whether to use the userspace
+                  implementation of Wireguard instead of the kernel one.
+                type: boolean
             type: object
           status:
             description: WireguardStatus defines the observed state of Wireguard

--- a/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
+++ b/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
@@ -57,6 +57,7 @@ spec:
               port:
                 description: A field that specifies the value to use for a nodePort
                   ServiceType
+                format: int32
                 type: integer
               serviceAnnotations:
                 additionalProperties:

--- a/pkg/api/v1alpha1/wireguard_types.go
+++ b/pkg/api/v1alpha1/wireguard_types.go
@@ -51,6 +51,8 @@ type WireguardSpec struct {
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 	// A boolean field that specifies whether IP forwarding should be enabled on the Wireguard VPN pod at startup. This can be useful to enable if the peers are having problems with sending traffic to the internet.
 	EnableIpForwardOnPodInit bool `json:"enableIpForwardOnPodInit,omitempty"`
+	// A boolean field that specifies whether to use the userspace implementation of Wireguard instead of the kernel one.
+	UseWgUserspaceImplementation bool `json:"useWgUserspaceImplementation,omitempty"`
 }
 
 // WireguardStatus defines the observed state of Wireguard


### PR DESCRIPTION
Related to https://github.com/jodevsa/wireguard-operator/issues/115.

I've added the `useWgUserspaceImplementation` bool option to Wireguard.spec and made the controller use it.

If `useWgUserspaceImplementation` isn't used or is `false` then the agent container in the VPN Deployment won't have the `--wg-use-userspace-implementation` flag, if it's `true` then the flag will be there and the userspace implementation will be used.

I've tried creating a test for it but with no luck.
`pkg/controllers/wireguard_controller_test.go`
```It("forces usage of Wireguard userspace implementation through Wireguard.Spec.UseWgUserspaceImplementation", func() {
			useWgUserspace := true

			wgServer := &v1alpha1.Wireguard{
				ObjectMeta: metav1.ObjectMeta{
					Name:      wgKey.Name,
					Namespace: wgKey.Namespace,
				},
				Spec: v1alpha1.WireguardSpec{
					UseWgUserspaceImplementation: useWgUserspace,
				},
			}
			Expect(k8sClient.Create(context.Background(), wgServer)).Should(Succeed())

			// new
			depName := wgKey.Name + "-dep"
			depKey := types.NamespacedName{
				Namespace: wgKey.Namespace,
				Name:      depName,
			}

			expectedCmdFlag := "--wg-use-userspace-implementation2"

			Eventually(func() []string {
				dep := &appsv1.Deployment{}
				k8sClient.Get(context.Background(), depKey, dep)
				fmt.Println(dep)
				for _, c := range dep.Spec.Template.Spec.Containers {
					if c.Name == "agent" {
						return c.Command
					}
				}
				return []string{}
			}, Timeout, Interval).Should(ContainElements(expectedCmdFlag))
		})
```
but it never has the flag
```
    Timed out after 2.001s.
    Expected
        <[]string | len:11, cap:16>: [
            "agent",
            "--v",
            "11",
            "--wg-iface",
            "wg0",
            "--wg-listen-port",
            "51820",
            "--state",
            "/tmp/wireguard/state.json",
            "--wg-userspace-implementation-fallback",
            "wireguard-go",
        ]
    to contain elements
        <[]string | len:1, cap:1>: [
            "--wg-use-userspace-implementation",
        ]
    the missing elements were
        <[]string | len:1, cap:1>: [
            "--wg-use-userspace-implementation",
        ]
```

I've tested manually on my cluster all 3 options (true, false and not specified) and they work (had to delete the deployment after changing the Wireguard spec so controller recreates it).