### PR TITLE
chore: fix staticcheck issues

### DIFF
--- a/pkg/api/v1alpha1/wireguard_types.go
+++ b/pkg/api/v1alpha1/wireguard_types.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	Pending string = "pending"
-	Error          = "error"
-	Ready          = "ready"
+	Pending = "pending"
+	Error   = "error"
+	Ready   = "ready"
 )
 
 type WgStatusReport struct {

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -38,7 +37,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 var wgTestImage = "test-image"

--- a/pkg/controllers/wireguard_controller.go
+++ b/pkg/controllers/wireguard_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/jodevsa/wireguard-operator/pkg/agent"
@@ -148,7 +149,7 @@ func getAvaialbleIp(cidr string, usedIps []string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("No available ip found in %s", cidr)
+	return "", fmt.Errorf("no available ip found in %s", cidr)
 }
 
 func (r *WireguardReconciler) getUsedIps(peers *v1alpha1.WireguardPeerList) []string {
@@ -404,8 +405,7 @@ func (r *WireguardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, nil
 		}
 
-		port = fmt.Sprint(svcFound.Spec.Ports[0].NodePort)
-		port = fmt.Sprint(svcFound.Spec.Ports[0].NodePort)
+		port = strconv.Itoa(int(svcFound.Spec.Ports[0].NodePort))
 
 		ips, err := r.getNodeIps(ctx, req)
 


### PR DESCRIPTION
Use [staticcheck](https://staticcheck.dev/) to find and fix correctness issues.

	❯ go run honnef.co/go/tools/cmd/staticcheck@latest ./...
	internal/iptables/iptables.go:61:3: should replace loop with rules = append(rules, EgressNetworkPolicyToIpTableRules(policy, peerChain)...) (S1011)
	internal/iptables/iptables.go:80:22: unnecessary use of fmt.Sprintf (S1039)
	internal/it/suite_test.go:32:5: var cfg is unused (U1000)
	internal/it/suite_test.go:34:5: var testEnv is unused (U1000)
	internal/it/suite_test.go:172:2: this value of b is never used (SA4006)
	internal/it/suite_test.go:185:2: this value of b is never used (SA4006)
	internal/it/suite_test.go:222:2: this value of err is never used (SA4006)
	pkg/api/v1alpha1/wireguard_types.go:26:2: only the first constant in this group has an explicit type (SA9004)
	pkg/controllers/suite_test.go:41:5: var cfg is unused (U1000)
	pkg/controllers/wireguard_controller.go:151:13: error strings should not be capitalized (ST1005)
	pkg/controllers/wireguard_controller.go:407:3: this value of port is never used (SA4006)
	pkg/controllers/wireguard_controller.go:407:10: Sprint doesn't have side effects and its return value is ignored (SA4017)
	pkg/wireguard/wireguard.go:63:2: this value of err is never used (SA4006)
	pkg/wireguard/wireguard.go:104:2: this value of link is never used (SA4006)
	pkg/wireguard/wireguard.go:155:2: this value of err is never used (SA4006)
	pkg/wireguard/wireguard.go:293:6: should omit comparison to bool constant, can be simplified to peer.Spec.Disabled (S1002)
	pkg/wireguard/wireguard.go:343:2: this value of err is never used (SA4006)
	exit status 1

Refs: #160