### PR TITLE
make controller deployment run as nobody and nogroup

### DIFF
--- a/bundle/manifests/wireguard-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/wireguard-operator.clusterserviceversion.yaml
@@ -220,15 +220,6 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 64Mi
-                securityContext:
-                  runAsNonRoot: false
-                  runAsGroup: 65534
-                  runAsUser: 65534
-                  allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-                  capabilities:
-                    drop:
-                      - ALL
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -257,17 +248,9 @@ spec:
                     cpu: 10m
                     memory: 64Mi
                 securityContext:
-                  runAsNonRoot: false
-                  runAsGroup: 65534
-                  runAsUser: 65534
                   allowPrivilegeEscalation: false
-                  readOnlyRootFilesystem: true
-                  capabilities:
-                    drop:
-                      - ALL
               securityContext:
                 runAsNonRoot: true
-                fsGroup: 65534
               serviceAccountName: wireguard-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/bundle/manifests/wireguard-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/wireguard-operator.clusterserviceversion.yaml
@@ -220,6 +220,15 @@ spec:
                   requests:
                     cpu: 5m
                     memory: 64Mi
+                securityContext:
+                  runAsNonRoot: false
+                  runAsGroup: 65534
+                  runAsUser: 65534
+                  allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  capabilities:
+                    drop:
+                      - ALL
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
@@ -248,9 +257,17 @@ spec:
                     cpu: 10m
                     memory: 64Mi
                 securityContext:
+                  runAsNonRoot: false
+                  runAsGroup: 65534
+                  runAsUser: 65534
                   allowPrivilegeEscalation: false
+                  readOnlyRootFilesystem: true
+                  capabilities:
+                    drop:
+                      - ALL
               securityContext:
                 runAsNonRoot: true
+                fsGroup: 65534
               serviceAccountName: wireguard-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -20,6 +20,15 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          runAsNonRoot: false
+          runAsGroup: 65534
+          runAsUser: 65534
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: 500m

--- a/config/default/manager_auth_proxy_patch.yaml.template
+++ b/config/default/manager_auth_proxy_patch.yaml.template
@@ -20,6 +20,15 @@ spec:
         - containerPort: 8443
           protocol: TCP
           name: https
+        securityContext:
+          runAsNonRoot: false
+          runAsGroup: 65534
+          runAsUser: 65534
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         resources:
           limits:
             cpu: 500m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -25,6 +25,7 @@ spec:
         control-plane: controller-manager
     spec:
       securityContext:
+        fsGroup: 65534
         runAsNonRoot: true
       containers:
       - command:
@@ -34,7 +35,14 @@ spec:
         image: controller:latest
         name: manager
         securityContext:
+          runAsNonRoot: false
+          runAsGroup: 65534
+          runAsUser: 65534
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
At the moment, the controller of this operator are running in nonRoot in deployment's securityContext, but the root filesystem is still readable, the user and group are not defined.

By setting 65334 uid and gid (nobody and nogroup), we make sure the controller will be running with least privilege. Also I set the fsGroup to 65334, so we make sure we turn all mounted volumes owned by nobody instead of root.

@jodevsa I am not sure if I have changed the manifest in the right place. If `/bundle` is generated, where should I edit instead? Also are you happy with making this operator tight in security by default? Or do you prefer leaving that for users to patch themselves?