### PR TITLE
feat: support ClusterIP service

### DIFF
--- a/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
+++ b/config/crd/bases/vpn.wireguard-operator.io_wireguards.yaml
@@ -196,8 +196,8 @@ spec:
                 type: object
               serviceType:
                 description: A field that specifies the type of Kubernetes service
-                  that should be used for the Wireguard VPN. This could be NodePort
-                  or LoadBalancer, depending on the needs of the deployment.
+                  that should be used for the Wireguard VPN. This could be ClusterIP,
+                  NodePort or LoadBalancer, depending on the needs of the deployment.
                 type: string
               useWgUserspaceImplementation:
                 description: A boolean field that specifies whether to use the userspace

--- a/pkg/api/v1alpha1/wireguard_types.go
+++ b/pkg/api/v1alpha1/wireguard_types.go
@@ -43,7 +43,7 @@ type WireguardSpec struct {
 	Address string `json:"address,omitempty"`
 	// A string field that specifies the DNS server(s) to be used by the peers.
 	Dns string `json:"dns,omitempty"`
-	// A field that specifies the type of Kubernetes service that should be used for the Wireguard VPN. This could be NodePort or LoadBalancer, depending on the needs of the deployment.
+	// A field that specifies the type of Kubernetes service that should be used for the Wireguard VPN. This could be ClusterIP, NodePort or LoadBalancer, depending on the needs of the deployment.
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 	// A field that specifies the value to use for a nodePort ServiceType
 	NodePort int32 `json:"port,omitempty"`

--- a/pkg/controllers/wireguard_controller.go
+++ b/pkg/controllers/wireguard_controller.go
@@ -439,6 +439,17 @@ func (r *WireguardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	}
 
+	if serviceType == corev1.ServiceTypeClusterIP {
+		if len(svcFound.Spec.Ports) == 0 {
+			err = r.updateStatus(ctx, req, wireguard, v1alpha1.WgStatusReport{Status: v1alpha1.Pending, Message: "Waiting for service with type ClusterIP to be ready"})
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			return ctrl.Result{}, nil
+		}
+	}
+
 	if wireguard.Status.Address != address || port != wireguard.Status.Port || dnsAddress != wireguard.Status.Dns {
 		updateWireguard := wireguard.DeepCopy()
 		updateWireguard.Status.Address = address

--- a/pkg/controllers/wireguard_controller_test.go
+++ b/pkg/controllers/wireguard_controller_test.go
@@ -67,7 +67,8 @@ func reconcileServiceWithTypeLoadBalancer(svcKey client.ObjectKey, hostname stri
 
 func reconcileServiceWithClusterIP(svcKey client.ObjectKey, port int32) error {
 	svc := &corev1.Service{}
-	k8sClient.Get(context.Background(), svcKey, svc)
+	Expect(k8sClient.Get(context.Background(), svcKey, svc)).Should(Succeed())
+
 	if svc.Spec.Type != corev1.ServiceTypeClusterIP {
 		return fmt.Errorf("ReconcileServiceWithClusterIP only reconsiles ClusterIP services")
 	}
@@ -560,6 +561,7 @@ Endpoint = %s:%s"`, peerKey.Name, peer.Spec.AllowedIPs, peer.Spec.Address, dnsSe
 			// match labels
 			Eventually(func() map[string]string {
 				svc := &corev1.Service{}
+				//nolint:errcheck
 				k8sClient.Get(context.Background(), serviceKey, svc)
 				return svc.Spec.Selector
 			}, Timeout, Interval).Should(BeEquivalentTo(expectedLabels))
@@ -567,12 +569,14 @@ Endpoint = %s:%s"`, peerKey.Name, peer.Spec.AllowedIPs, peer.Spec.Address, dnsSe
 			// match service type
 			Eventually(func() corev1.ServiceType {
 				svc := &corev1.Service{}
+				//nolint:errcheck
 				k8sClient.Get(context.Background(), serviceKey, svc)
 				return svc.Spec.Type
 			}, Timeout, Interval).Should(Equal(corev1.ServiceTypeClusterIP))
 
 			Eventually(func() v1alpha1.WireguardStatus {
 				wg := &v1alpha1.Wireguard{}
+				//nolint:errcheck
 				k8sClient.Get(context.Background(), wgKey, wg)
 				return wg.Status
 			}, Timeout, Interval).Should(Equal(v1alpha1.WireguardStatus{


### PR DESCRIPTION
This PR allow generation of a ClusterIP service. By doing so, we give user the freedom to choose how they want to expose their wireguard instance. For example, if they are using the Gateway CRD, they could use `UDPRoutes` to expose the wireguard instance