### PR TITLE
fix: update manifests version for kubectl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ If you are facing any problems please open an [issue](https://github.com/jodevsa
   * Not compatible with "Container-Optimized OS with containerd" node images
   * Not compatible with autopilot
 - [x] DigitalOcean Kubernetes
-  * requires `spec.serviceType: "NodePort"`. DigitalOcean LoadBalancer does not support UDP. 
+  * requires `spec.serviceType: "NodePort"`. DigitalOcean LoadBalancer does not support UDP.
 - [ ] Amazon EKS
 - [ ] Azure Kubernetes Service
+- [x] Hetzner Cloud
+  * requires `spec.serviceType: "NodePort"`. Hetzner Cloud LoadBalancer does not support UDP.
+- [x] Vultr
+- [x] Proxmox
 - [ ] ...?
 
 ## Architecture 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Endpoint = 32.121.45.102:51820
 
 ## How to deploy
 ```
-kubectl apply -f https://github.com/jodevsa/wireguard-operator/releases/download/v2.1.0/release.yaml
+kubectl apply -f https://github.com/jodevsa/wireguard-operator/releases/download/v2.7.0/release.yaml
 ```
 
 ## How to remove
 ```
-kubectl delete -f https://github.com/jodevsa/wireguard-operator/releases/download/v2.1.0/release.yaml
+kubectl delete -f https://github.com/jodevsa/wireguard-operator/releases/download/v2.7.0/release.yaml
 ```
 
 ## How to collaborate


### PR DESCRIPTION
Updated the kubectl apply command in the documentation to reference the latest release version of wireguard-operator.

- Changed the release version from v2.1.0 to v2.7.0.

This ensures users install the latest version with the correct source.